### PR TITLE
refactor: improving docs and parameter names 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,107 @@
 # How to contribute
 
-You can contribute by reporting issues or opening pull requests.
+Bug reports, documentation fixes, new methods and examples, or code changes.
 
-This is a small library: a few methods implemented in C++ with Python bindings, plus examples showing how to use them. If you want to propose a new method, it should come with:
 
-- the implementation in C++ with Python bindings
-- an update to the [examples](https://github.com/roliveira/nilt/tree/main/examples), especially the [verification examples](https://github.com/roliveira/nilt/tree/main/examples/verification), adding error metrics and a timing benchmark against the test functions
+## Reporting issues
 
-New examples are also welcome. 
+- Bugs: include OS, compiler or Python version, `nilt` version, and a minimal example to reproduce it.
+- Feature requests: describe the use case and link to relevant papers.
+- New methods or examples: see below.
+
+
+## Development setup
+
+CMake handles C++; [uv](https://docs.astral.sh/uv/) handles Python.
+
+```bash
+git clone https://github.com/roliveira/nilt.git
+cd nilt
+
+# Python (with dev deps)
+uv sync --extra dev
+
+# C++ (optional)
+cmake -S . -B build -DNILT_BUILD_TESTS=ON -DNILT_BUILD_EXAMPLES=ON
+cmake --build build --parallel
+```
+
+
+## Running tests
+
+CI covers Ubuntu, macOS, and Windows (ARM included), Python 3.9-3.13. Everything must pass before merge.
+
+
+### C++
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+
+### Python
+
+```bash
+uv run pytest -v
+```
+
+
+## Commit messages
+
+[Conventional Commits](https://www.conventionalcommits.org/), enforced by [python-semantic-release](https://python-semantic-release.readthedocs.io/). Every commit to `main` is checked for version bumps:
+
+| Prefix | Effect |
+|--------|--------|
+| `feat` | minor bump |
+| `fix`, `perf` | patch bump |
+| `refactor`, `build`, `ci`, `docs`, `style`, `test`, `chore` | no bump |
+
+```
+feat: add Weeks method for numerical inversion
+fix: correct tolerance in DeHoog
+docs: add heat conduction example
+```
+
+
+## Pull requests
+
+1. Fork and branch from `main`.
+2. Follow the commit conventions.
+3. Run both test suites locally.
+4. Open a PR. CI runs the full matrix.
+5. After merge, a release is created automatically if the commits call for one.
+
+
+## Adding a new method
+
+This is a small library, so a new method should include:
+
+- C++ implementation with pybind11 bindings
+- Tests: `tests/test_<method>.cpp` and `tests/test_<method>.py`
+- Entries in the [verification suite](https://github.com/roliveira/nilt/tree/main/examples/verification)
+- README updates (parameters, usage)
+
+
+## Adding examples
+
+Put new examples in the appropriate `examples/` subdirectory, document in its `README.md`, and confirm they run:
+
+```bash
+uv sync --extra plot
+uv run python examples/<your_example>.py
+```
+
+
+## Releases
+
+On push to `main`, CI runs tests, then `python-semantic-release` checks commits since the last tag. If a bump is warranted it updates versions, tags, and publishes a GitHub Release. You don't touch versions or tags yourself.
+
+
+## GitHub Actions workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `cpp-tests.yml` | PR to `main`, manual | C++ test suite |
+| `python-tests.yml` | PR to `main`, manual | pytest across OS/Python matrix |
+| `release.yml` | Push to `main`, manual | Tests + semantic release |
+| `draft-pdf.yml` | PR to `main`, manual | JOSS paper PDF |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A C++ header-only library (with Python bindings) for numerically inverting Lapla
 
 [^1]: This work was partly developed in [Oliveira, R. (2021)](https://doi.org/10.25560/92253).
 
+
 ## Statement of need
 
 Many problems in physics and engineering are easier to solve in the Laplace domain than in the time domain. Groundwater drawdown, heat conduction in semi-infinite solids, diffusion from spheres and cylinders, viscoelastic creep are great examples that have closed-form Laplace-domain solutions that are difficult or impossible to invert analytically.
@@ -18,6 +19,7 @@ Existing tools are scattered:
 - No other C++ library packages multiple algorithms behind a common interface.
 
 NILT provides Stehfest, Talbot, and De Hoog in a dependency-free C++ header that compiles with any C++14 toolchain. The Python bindings expose the same compiled code for scripting and prototyping. 
+
 
 ## Quick Start
 
@@ -62,6 +64,7 @@ t = np.linspace(0.1, 10, 100)
 results = invert(DeHoog(), lambda s: 1.0 / (s + 1.0), t)
 ```
 
+
 ## Methods
 
 Three algorithms are implemented:
@@ -79,6 +82,7 @@ All algorithms accept any callable via the free function or direct call:
 | Free function | `nilt::invert(algo, F, t)` | `nilt.invert(algo, F, t)` |
 | Direct call   | `algo(F, t)`               | `algo(F, t)`              |
 
+
 ### Parameters
 
 Each algorithm exposes tunable parameters (identical names in C++ and Python):
@@ -91,6 +95,7 @@ Each algorithm exposes tunable parameters (identical names in C++ and Python):
 | DeHoog   | `M` | 40 | Order of approximation |
 | DeHoog   | `T_factor` | 4.0 | Period factor ($T = T_{\text{factor}} \cdot t$) |
 | DeHoog   | `tol` | 1e-16 | Tolerance for integration limit |
+
 
 ## Test Functions
 
@@ -109,6 +114,7 @@ The [verification suite](examples/verification/) evaluates all methods against k
 | 9 | $\cos t$ | $s/(s^2+1)$ | Abate & Whitt |
 | 10 | $e^{-t}\sin t$ | $1/((s+1)^2+1)$ | Abate & Whitt |
 
+
 ## Benchmark Results
 
 See the [verification example](examples/verification/) for full the results. The table
@@ -126,6 +132,7 @@ below shows a test function from Stehfest (1970) ($f(t) = 1/\sqrt{\pi t}$) as an
 | 8 | 1.9947e-01 | 1.9947e-01 | 4.92e-06 | 1.9947e-01 | 4.82e-12 | 1.9947e-01 | 2.70e-14 |
 | 9 | 1.8806e-01 | 1.8806e-01 | 6.24e-06 | 1.8806e-01 | 4.61e-12 | 1.8806e-01 | 3.26e-14 |
 | 10 | 1.7841e-01 | 1.7841e-01 | 5.70e-06 | 1.7841e-01 | 4.84e-12 | 1.7841e-01 | 6.02e-14 |
+
 
 ## Building
 
@@ -156,6 +163,7 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
+
 ### Python bindings (pybind11)
 
 The Python package is built and installed automatically from `pyproject.toml`
@@ -180,11 +188,13 @@ Once installed, `from nilt import ...` works as expected. The `invert` function
 accepts both scalar `float` and NumPy array arguments. 
 Using NumPy arrays is slightly more efficient than having to evaluate several individual floats at a time. 
 
+
 ### Python tests (pytest)
 
 ```bash
 uv run pytest                  # or simply pytest (with venv activated)
 ```
+
 
 ## Running the Verification Suite
 
@@ -197,6 +207,7 @@ python ../plot_verification.py # reads from build/, writes PNGs there
 # Python (from repo root, with .venv activated)
 python examples/verification/verification.py   # writes py_*.csv to build/
 ```
+
 
 ## Examples
 
@@ -216,6 +227,11 @@ Each subdirectory contains a `README.md` with the mathematical formulation and
 a `plot_<example>.py` script to visualize the results. Every C++ example has a matching
 Python script (`.py`) that produces identical results. Binaries are placed in a `build/`
 subdirectory next to their sources; the output CSVs and PNGs are also there.
+
+
+## Contributing
+
+Contributions for bugs, features, other methods and examples are all welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, commit conventions, pull request guidelines and etc.
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ Each algorithm exposes tunable parameters (identical names in C++ and Python):
 | Class | Parameter | Default | Description |
 |-------|-----------|---------|-------------|
 | Stehfest | `N` | 18 | Number of terms (must be even) |
-| Talbot   | `n` | 50 | Number of quadrature points |
-| Talbot   | `shift` | 0.0 | Contour shift parameter |
+| Talbot   | `N` | 50 | Number of quadrature points |
+| Talbot   | `SHIFT` | 0.0 | Contour shift parameter |
 | DeHoog   | `M` | 40 | Order of approximation |
-| DeHoog   | `T_factor` | 4.0 | Period factor ($T = T_{\text{factor}} \cdot t$) |
-| DeHoog   | `tol` | 1e-16 | Tolerance for integration limit |
+| DeHoog   | `T_FACTOR` | 4.0 | Period factor ($T = T_{\text{FACTOR}} \cdot t$) |
+| DeHoog   | `TOL` | 1e-16 | Tolerance for integration limit |
 
 
 ## Test Functions

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Many problems in physics and engineering are easier to solve in the Laplace doma
 
 Existing tools are scattered:
 
-- MATLAB's `ilaplace` implements a inverse Laplace transform but it has no access to individual methods or parameters within it, and do not offer open-source license. 
-- Python's `mpmath.invertlaplace` provides all three families of methods (and Cohen method as well) but is written in pure Python with arbitrary-precision arithmetic, but a Python-first implementation is far slower when you need to invert at thousands of points.
+- MATLAB's `ilaplace` implements an inverse Laplace transform but it has no access to individual methods or parameters within it, and does not offer an open-source license.
+- Python's `mpmath.invertlaplace` provides all three families of methods (and Cohen method as well) and is written in pure Python with arbitrary-precision arithmetic, so a Python-first implementation is far slower when you need to invert at thousands of points.
 - The [`ilt`](https://github.com/nocliper/ilt) package wraps a single algorithm and it provides an implementation that is too tightly integrated to the application (transient spectroscopy). 
 - No other C++ library packages multiple algorithms behind a common interface.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ double f = nilt::invert(nilt::Talbot{}, [](auto s) { return 1.0 / (s + 1.0); }, 
 nilt::DeHoog dh;
 double f = dh([](auto s) { return 1.0 / (s + 1.0); }, 2.5);
 
-// Custom parameters
+// Custom parameters (see Parameters section for full list)
 nilt::Stehfest algo;
 algo.N = 12;
 double f = nilt::invert(algo, my_func, 1.0);
@@ -54,7 +54,7 @@ f = invert(Talbot(), lambda s: 1.0 / (s + 1.0), 1.0)
 dh = DeHoog()
 f = dh(lambda s: 1.0 / (s + 1.0), 2.5)
 
-# Custom parameters
+# Custom parameters (see Parameters section for full list)
 algo = Stehfest()
 algo.N = 12
 f = invert(algo, my_func, 1.0)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,22 @@
 
 # NILT: Numerical Inverse Laplace Transform Methods
 
-A C++ header-only library (with Python bindings) for numerically inverting Laplace transforms. Three algorithms are provided: Gaver-Stehfest, fixed Talbot, and De Hoog et al. All share the same callable interface in both languages.
+A C++ header-only library (with Python bindings) for numerically inverting Laplace transforms[^1]. Three algorithms are provided: Gaver-Stehfest, fixed Talbot, and De Hoog et al. All share the same callable interface in both languages.
 
-This work was partly developed in [Oliveira, R. (2021)](https://doi.org/10.25560/92253).
+[^1]: This work was partly developed in [Oliveira, R. (2021)](https://doi.org/10.25560/92253).
+
+## Statement of need
+
+Many problems in physics and engineering are easier to solve in the Laplace domain than in the time domain. Groundwater drawdown, heat conduction in semi-infinite solids, diffusion from spheres and cylinders, viscoelastic creep are great examples that have closed-form Laplace-domain solutions that are difficult or impossible to invert analytically.
+
+Existing tools are scattered:
+
+- MATLAB's `ilaplace` implements a inverse Laplace transform but it has no access to individual methods or parameters within it, and do not offer open-source license. 
+- Python's `mpmath.invertlaplace` provides all three families of methods (and Cohen method as well) but is written in pure Python with arbitrary-precision arithmetic, but a Python-first implementation is far slower when you need to invert at thousands of points.
+- The [`ilt`](https://github.com/nocliper/ilt) package wraps a single algorithm and it provides an implementation that is too tightly integrated to the application (transient spectroscopy). 
+- No other C++ library packages multiple algorithms behind a common interface.
+
+NILT provides Stehfest, Talbot, and De Hoog in a dependency-free C++ header that compiles with any C++14 toolchain. The Python bindings expose the same compiled code for scripting and prototyping. 
 
 ## Quick Start
 

--- a/include/dehoog.hpp
+++ b/include/dehoog.hpp
@@ -18,8 +18,8 @@ public:
     static constexpr const char* name = "DeHoog";
 
     int    M        = 40;       // order of approximation (number of terms)
-    double T_factor = 4.0;      // period factor (T = T_factor * t)
-    double tol      = 1.0e-16;  // tolerance for integration limit
+    double T_FACTOR = 4.0;      // period factor (T = T_FACTOR * t)
+    double TOL      = 1.0e-16;  // tolerance for integration limit
 
     // Evaluate the inverse Laplace transform at time t.
     // Fs must be callable as Fs(std::complex<double>) -> std::complex<double>.
@@ -31,8 +31,8 @@ public:
 
         int twoM = 2 * M;
 
-        double T     = T_factor * t;
-        double gamma = -0.5 * std::log(tol) / T;
+        double T     = T_FACTOR * t;
+        double gamma = -0.5 * std::log(TOL) / T;
 
         // Evaluate F(s) at quadrature points
         std::vector<std::complex<double>> Fc(twoM + 1);

--- a/include/talbot.hpp
+++ b/include/talbot.hpp
@@ -18,8 +18,8 @@ class Talbot
 public:
     static constexpr const char* name = "Talbot";
 
-    int    n     = 50;     // number of quadrature points
-    double shift = 0.0;    // contour shift parameter
+    int    N     = 50;     // number of quadrature points
+    double SHIFT = 0.0;    // contour shift parameter
 
     // Evaluate the inverse Laplace transform at time t.
     // Fs must be callable as Fs(std::complex<double>) -> std::complex<double>.
@@ -29,19 +29,19 @@ public:
         if (t <= 0.0)
             throw std::domain_error("Talbot: t must be positive");
 
-        double h = 2.0 * pi / n;
+        double h = 2.0 * pi / N;
         std::complex<double> ans(0.0, 0.0);
 
-        for (int k = 0; k < n; ++k)
+        for (int k = 0; k < N; ++k)
         {
             double theta = -pi + (k + 0.5) * h;
             double ct = std::cos(0.6407 * theta);
             double st = std::sin(0.6407 * theta);
 
-            std::complex<double> z = shift + static_cast<double>(n) / t
+            std::complex<double> z = SHIFT + static_cast<double>(N) / t
                 * (0.5017 * theta * ct / st + std::complex<double>(-0.6122, 0.2645 * theta));
 
-            std::complex<double> dz = static_cast<double>(n) / t
+            std::complex<double> dz = static_cast<double>(N) / t
                 * (-0.5017 * 0.6407 * theta / (st * st) + 0.5017 * ct / st
                    + std::complex<double>(0.0, 0.2645));
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -32,13 +32,13 @@ All three algorithms share the same two-argument interface in both C++ and Pytho
 **Python**
 
 ```python
-algo(F, t)
+nilt.invert(algorithm, F, t)
 ```
 
 **C++**
 
 ```cpp
-nilt::invert(algo, F, t)
+nilt::invert(algorithm, F, t)
 ```
 
 The Stehfest algorithm requires that $F(s)$ be real-valued while Talbot and De Hoog operate on complex-valued transforms. Each algorithm exposes tunable parameters (number of terms, tolerance, contour shift) with defaults that work well for most problems.
@@ -52,8 +52,8 @@ Many problems in physics and engineering are easier to solve in the Laplace doma
 Existing tools are scattered:
 
 - MATLAB's `ilaplace` implements a inverse Laplace transform but it has no access to individual methods or parameters within it, and do not offer open-source license. 
-- Python's `mpmath.invertlaplace` provides all three families of methods (and Cohen method as well) but is written in pure Python with arbitrary-precision arithmetic, but a Python-first implementaiton is far slower when you need to invert at thousands of points.
-- The [`ilt`](https://github.com/nocliper/ilt) package wraps a single algorithm and it provides an implementation that is too tightly integrated to the applicatoin (transient spectroscopy). 
+- Python's `mpmath.invertlaplace` provides all three families of methods (and Cohen method as well) but is written in pure Python with arbitrary-precision arithmetic, but a Python-first implementation is far slower when you need to invert at thousands of points.
+- The [`ilt`](https://github.com/nocliper/ilt) package wraps a single algorithm and it provides an implementation that is too tightly integrated to the application (transient spectroscopy). 
 - No other C++ library packages multiple algorithms behind a common interface.
 
 NILT provides Stehfest, Talbot, and De Hoog in a dependency-free C++ header that compiles with any C++14 toolchain. The Python bindings expose the same compiled code for scripting and prototyping. 

--- a/python/nilt_bind.cpp
+++ b/python/nilt_bind.cpp
@@ -136,9 +136,9 @@ PYBIND11_MODULE(_nilt, m)
         "Fixed Talbot algorithm for numerical inverse Laplace transform.\n"
         "F(s) must accept a complex and return a complex.")
         .def(py::init<>())
-        .def_readwrite("n", &nilt::Talbot::n,
+        .def_readwrite("N", &nilt::Talbot::N,
             "Number of quadrature points (default 50)")
-        .def_readwrite("shift", &nilt::Talbot::shift,
+        .def_readwrite("SHIFT", &nilt::Talbot::SHIFT,
             "Contour shift parameter (default 0.0)")
         .def("__call__", &invert_talbot,
             py::arg("Fs"), py::arg("t"),
@@ -153,9 +153,9 @@ PYBIND11_MODULE(_nilt, m)
         .def(py::init<>())
         .def_readwrite("M", &nilt::DeHoog::M,
             "Order of approximation (default 40)")
-        .def_readwrite("T_factor", &nilt::DeHoog::T_factor,
+        .def_readwrite("T_FACTOR", &nilt::DeHoog::T_FACTOR,
             "Period factor (default 4.0)")
-        .def_readwrite("tol", &nilt::DeHoog::tol,
+        .def_readwrite("TOL", &nilt::DeHoog::TOL,
             "Tolerance (default 1e-16)")
         .def("__call__", &invert_dehoog,
             py::arg("Fs"), py::arg("t"),

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -75,21 +75,21 @@ class TestStehfestBindingExposesMutableN:
 
 class TestTalbotBindingExposesMutableParameters:
 
-    def test_read_default_n(self):
-        assert nilt.Talbot().n == 50
+    def test_read_default_N(self):
+        assert nilt.Talbot().N == 50
 
-    def test_read_default_shift(self):
-        assert nilt.Talbot().shift == 0.0
+    def test_read_default_SHIFT(self):
+        assert nilt.Talbot().SHIFT == 0.0
 
-    def test_write_n_persists(self):
+    def test_write_N_persists(self):
         algo = nilt.Talbot()
-        algo.n = 100
-        assert algo.n == 100
+        algo.N = 100
+        assert algo.N == 100
 
-    def test_write_shift_persists(self):
+    def test_write_SHIFT_persists(self):
         algo = nilt.Talbot()
-        algo.shift = 2.0
-        assert algo.shift == 2.0
+        algo.SHIFT = 2.0
+        assert algo.SHIFT == 2.0
 
 
 class TestDeHoogBindingExposesMutableParameters:
@@ -97,26 +97,26 @@ class TestDeHoogBindingExposesMutableParameters:
     def test_read_default_M(self):
         assert nilt.DeHoog().M == 40
 
-    def test_read_default_T_factor(self):
-        assert nilt.DeHoog().T_factor == 4.0
+    def test_read_default_T_FACTOR(self):
+        assert nilt.DeHoog().T_FACTOR == 4.0
 
-    def test_read_default_tol(self):
-        assert nilt.DeHoog().tol == 1e-16
+    def test_read_default_TOL(self):
+        assert nilt.DeHoog().TOL == 1e-16
 
     def test_write_M_persists(self):
         algo = nilt.DeHoog()
         algo.M = 20
         assert algo.M == 20
 
-    def test_write_T_factor_persists(self):
+    def test_write_T_FACTOR_persists(self):
         algo = nilt.DeHoog()
-        algo.T_factor = 8.0
-        assert algo.T_factor == 8.0
+        algo.T_FACTOR = 8.0
+        assert algo.T_FACTOR == 8.0
 
-    def test_write_tol_persists(self):
+    def test_write_TOL_persists(self):
         algo = nilt.DeHoog()
-        algo.tol = 1e-10
-        assert algo.tol == 1e-10
+        algo.TOL = 1e-10
+        assert algo.TOL == 1e-10
 
 
 class TestAllThreeAlgorithmsCallable:

--- a/tests/test_dehoog.cpp
+++ b/tests/test_dehoog.cpp
@@ -92,13 +92,13 @@ TEST_CASE("DeHoog inverts 1/((s+1)^2+1) to exp(-t)sin(t)",
     }
 }
 
-TEST_CASE("DeHoog default parameters M=40 T_factor=4.0 tol=1e-16",
+TEST_CASE("DeHoog default parameters M=40 T_FACTOR=4.0 TOL=1e-16",
           "[dehoog][defaults]")
 {
     nilt::DeHoog algo;
     REQUIRE(algo.M == 40);
-    REQUIRE(algo.T_factor == 4.0);
-    REQUIRE(algo.tol == 1e-16);
+    REQUIRE(algo.T_FACTOR == 4.0);
+    REQUIRE(algo.TOL == 1e-16);
 }
 
 TEST_CASE("DeHoog name is DeHoog", "[dehoog][name]")

--- a/tests/test_dehoog.py
+++ b/tests/test_dehoog.py
@@ -72,26 +72,26 @@ class TestDeHoogDefaults:
     def test_default_M_is_40(self):
         assert nilt.DeHoog().M == 40
 
-    def test_default_T_factor_is_4(self):
-        assert nilt.DeHoog().T_factor == 4.0
+    def test_default_T_FACTOR_is_4(self):
+        assert nilt.DeHoog().T_FACTOR == 4.0
 
-    def test_default_tol_is_1e16(self):
-        assert nilt.DeHoog().tol == 1e-16
+    def test_default_TOL_is_1e16(self):
+        assert nilt.DeHoog().TOL == 1e-16
 
     def test_M_is_mutable(self):
         algo = nilt.DeHoog()
         algo.M = 60
         assert algo.M == 60
 
-    def test_T_factor_is_mutable(self):
+    def test_T_FACTOR_is_mutable(self):
         algo = nilt.DeHoog()
-        algo.T_factor = 2.0
-        assert algo.T_factor == 2.0
+        algo.T_FACTOR = 2.0
+        assert algo.T_FACTOR == 2.0
 
-    def test_tol_is_mutable(self):
+    def test_TOL_is_mutable(self):
         algo = nilt.DeHoog()
-        algo.tol = 1e-12
-        assert algo.tol == 1e-12
+        algo.TOL = 1e-12
+        assert algo.TOL == 1e-12
 
 
 class TestDeHoogDomainError:

--- a/tests/test_talbot.cpp
+++ b/tests/test_talbot.cpp
@@ -92,11 +92,11 @@ TEST_CASE("Talbot inverts 1/((s+1)^2+1) to exp(-t)sin(t)",
     }
 }
 
-TEST_CASE("Talbot default parameters n=50 shift=0", "[talbot][defaults]")
+TEST_CASE("Talbot default parameters N=50 SHIFT=0", "[talbot][defaults]")
 {
     nilt::Talbot algo;
-    REQUIRE(algo.n == 50);
-    REQUIRE(algo.shift == 0.0);
+    REQUIRE(algo.N == 50);
+    REQUIRE(algo.SHIFT == 0.0);
 }
 
 TEST_CASE("Talbot name is Talbot", "[talbot][name]")
@@ -111,11 +111,11 @@ TEST_CASE("Talbot throws domain_error for t <= 0", "[talbot][domain]")
     REQUIRE_THROWS_AS(nilt::invert(algo, Fs_exp_decay, -1.0), std::domain_error);
 }
 
-TEST_CASE("Talbot with n=100 inverts exp_decay",
+TEST_CASE("Talbot with N=100 inverts exp_decay",
           "[talbot][parameters]")
 {
     nilt::Talbot algo;
-    algo.n = 100;
+    algo.N = 100;
     double result = nilt::invert(algo, Fs_exp_decay, 2.0);
     REQUIRE_THAT(result, WithinRel(std::exp(-2.0), TALBOT_REL_TOL_LARGE));
 }

--- a/tests/test_talbot.py
+++ b/tests/test_talbot.py
@@ -69,21 +69,21 @@ class TestTalbotInvertPolynomial:
 
 class TestTalbotDefaults:
 
-    def test_default_n_is_50(self):
-        assert nilt.Talbot().n == 50
+    def test_default_N_is_50(self):
+        assert nilt.Talbot().N == 50
 
-    def test_default_shift_is_zero(self):
-        assert nilt.Talbot().shift == 0.0
+    def test_default_SHIFT_is_zero(self):
+        assert nilt.Talbot().SHIFT == 0.0
 
-    def test_n_is_mutable(self):
+    def test_N_is_mutable(self):
         algo = nilt.Talbot()
-        algo.n = 100
-        assert algo.n == 100
+        algo.N = 100
+        assert algo.N == 100
 
-    def test_shift_is_mutable(self):
+    def test_SHIFT_is_mutable(self):
         algo = nilt.Talbot()
-        algo.shift = 1.5
-        assert algo.shift == 1.5
+        algo.SHIFT = 1.5
+        assert algo.SHIFT == 1.5
 
 
 class TestTalbotDomainError:

--- a/verification/benchmark_timing.cpp
+++ b/verification/benchmark_timing.cpp
@@ -61,14 +61,14 @@ int main()
         std::cout << "Stehfest  N=" << N  << "  " << us << " us" << std::endl;
     }
 
-    // Talbot: vary n
-    for (int n : {5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200})
+    // Talbot: vary N
+    for (int N : {5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200})
     {
         nilt::Talbot algo;
-        algo.n = n;
+        algo.N = N;
         double us = time_inversion(algo, Fs_cplx);
-        ofs << "Talbot," << n << "," << us << std::endl;
-        std::cout << "Talbot    n=" << n  << "  " << us << " us" << std::endl;
+        ofs << "Talbot," << N << "," << us << std::endl;
+        std::cout << "Talbot    N=" << N  << "  " << us << " us" << std::endl;
     }
 
     // DeHoog: vary M

--- a/verification/benchmark_timing.py
+++ b/verification/benchmark_timing.py
@@ -54,13 +54,13 @@ with open(out, "w") as f:
         f.write(f"Stehfest,{N},{us:.6f}\n")
         print(f"Stehfest  N={N:3d}  {us:.1f} us")
 
-    # Talbot: vary n
-    for n in [5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200]:
+    # Talbot: vary N
+    for N in [5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200]:
         algo = nilt.Talbot()
-        algo.n = n
+        algo.N = N
         us = time_inversion(algo, Fs_cplx)
-        f.write(f"Talbot,{n},{us:.6f}\n")
-        print(f"Talbot    n={n:3d}  {us:.1f} us")
+        f.write(f"Talbot,{N},{us:.6f}\n")
+        print(f"Talbot    N={N:3d}  {us:.1f} us")
 
     # DeHoog: vary M
     for M in [5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200]:


### PR DESCRIPTION
Refactor the README.md to include, a statement of need, an explicit mention to the CONTRIBUTING.md, and add a remark about the full list of parameters in the quickstart examples.

Also renamed all lowercase parameter variables to uppercase.

BREAKING CHANGE: Method parameter variables are all uppercase now (e.g. `Talbot.n` is now `Talbot.N`).